### PR TITLE
Delete the bin folder for arm64 & x64 macOS builds once universal binaries are been successfully created

### DIFF
--- a/.teamcity/_Self.kt/buildTypes/CreateUniversalBuilds.kt
+++ b/.teamcity/_Self.kt/buildTypes/CreateUniversalBuilds.kt
@@ -75,6 +75,8 @@ class UniversalBuild() : BuildType({
                 cp %system.teamcity.build.workingDir%/bin/* %universal-output-dir%/%universal-bin-path%
                 rm -r %universal-output-dir%/%x64-lib-path%
                 rm -r %universal-output-dir%/%arm64-lib-path%
+                rm -r %universal-output-dir%/%x64-bin-path%
+                rm -r %universal-output-dir%/%arm64-bin-path%
             """.trimIndent()
         }
     }


### PR DESCRIPTION
Normally on macOS, there's nothing in the binary directory to be deleted after the lipo steps run to create universal binaries, as .so files are stored in `lib/`. however with Mesh, there are executables stored in the `bin/` directory. 

arm64 & x64 macOS binaries need to be deleted before the perforce publish step runs so they don't end up in the perforce branch.