### PR TITLE
Use HTTPS for the vcpkg registries

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vendor/github.com/microsoft/vcpkg"]
 	path = vendor/github.com/microsoft/vcpkg
-	url = git@github.com:microsoft/vcpkg.git
+	url = https://github.com/microsoft/vcpkg
 [submodule "vendor/github.com/moltenVK"]
 	path = vendor/github.com/moltenVK
 	url = https://github.com/KhronosGroup/MoltenVK.git
@@ -9,7 +9,7 @@
 	url = https://github.com/ufbx/ufbx.git
 [submodule "vendor/github.com/carbonengine/vcpkg-registry"]
 	path = vendor/github.com/carbonengine/vcpkg-registry
-	url = git@github.com:carbonengine/vcpkg-registry.git
+	url = https://github.com/carbonengine/vcpkg-registry
 [submodule "vendor/github.com/FortAwesome/Font-Awesome"]
 	path = vendor/github.com/FortAwesome/Font-Awesome
 	url = https://github.com/FortAwesome/Font-Awesome

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -11,11 +11,15 @@
       "baseline": "ddc1854a3303051c9206ffac931b19174c30e707",
       "packages": [ "simplygon" ]
     },
-	{
-	  "kind": "git",
-	  "repository": "git@github.com:carbonengine/vcpkg-registry.git",
-	  "baseline": "87fbb75936f134fecccd01718e13216a9058713d",
-	  "packages": [ "python3", "carbon-math", "ccp-debug-info" ]
-	}
+    {
+      "kind": "git",
+      "repository": "https://github.com/carbonengine/vcpkg-registry.git",
+      "baseline": "87fbb75936f134fecccd01718e13216a9058713d",
+      "packages": [
+        "python3",
+        "carbon-math",
+        "ccp-debug-info"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
For vcpkg, it is much more common to use HTTPS for public registries. Accessing them via SSH isn't always possible, as it requires a key pre-installed.

---

This repo has a reference to `git@github.com:ccpgames/carbon-vcpkg-registry.git`. Nothing wrong with that, just different from the rest.


###### Full disclosure: I am employed by Fenris Creations, although I have no involvement with the Carbon project. I work on this in my free time under my own name.